### PR TITLE
Update to retrieve the list of friends' names 

### DIFF
--- a/BackendTestTool/Main.java
+++ b/BackendTestTool/Main.java
@@ -262,7 +262,7 @@ public class Main {
         }  catch (Exception e) {
             e.printStackTrace();
         }
-        return res.get("friendEmails").toString();
+        return res.get("friendList").toString();
     }
 
     private static void removeFriend(String token, String friendEmail) {

--- a/BackendTestTool/Main.java
+++ b/BackendTestTool/Main.java
@@ -258,7 +258,7 @@ public class Main {
             e.printStackTrace();
         }
         
-        return res.get("friendList").toString();
+        return res.get("friendEmails").toString();
     }
 
     private static void removeFriend(String token, String friendEmail) {

--- a/BackendTestTool/Main.java
+++ b/BackendTestTool/Main.java
@@ -31,20 +31,23 @@ public class Main {
                 update(token);
             }
             System.out.println("======= ==========MAIN========= =======");
-            System.out.println("0. Sign up");
-            System.out.println("1. Sign in");
-            System.out.println("2. Check Friend Request");
-            System.out.println("3. Request Friend");
-            System.out.println("4. Accept/Decline Friend Request");
-            System.out.println("5. Remove Friends");
-            System.out.println("6. Check Transactions");
-            System.out.println("7. Send Money");
-            System.out.println("8. Request Money");
-            System.out.println("9. Accept Transaction");
+            System.out.println(" 0. Sign up");
+            System.out.println(" 1. Sign in");
+            System.out.println(" 2. Check Friend Request");
+            System.out.println(" 3. Request Friend");
+            System.out.println(" 4. Accept/Decline Friend Request");
+            System.out.println(" 5. Remove Friends");
+            System.out.println(" 6. Check Transactions");
+            System.out.println(" 7. Send Money");
+            System.out.println(" 8. Request Money");
+            System.out.println(" 9. Accept Transaction");
+            System.out.println("10. Exit");
+            System.out.print("\n>> ");
 
             String input = sc.nextLine();
+            input = input.trim();
             int menu = 0;
-            if (input.length() == 1 && input.charAt(0) >= '0' && input.charAt(0) <= '9') {
+            if (input.charAt(0) >= '0' && input.charAt(0) <= '9') {
                 menu = Integer.parseInt(input);
             } else {
                 continue;
@@ -135,6 +138,8 @@ public class Main {
                 System.out.print("\n");
                 boolean accept = Yn.equalsIgnoreCase("y");
                 confirmTransaction(token, tid, accept);
+            } else if (menu == 10) {
+                break;
             }
         }
     }
@@ -257,7 +262,6 @@ public class Main {
         }  catch (Exception e) {
             e.printStackTrace();
         }
-        
         return res.get("friendEmails").toString();
     }
 

--- a/Test2/app/src/main/java/com/example/test2/ApiCallMaker.java
+++ b/Test2/app/src/main/java/com/example/test2/ApiCallMaker.java
@@ -116,7 +116,7 @@ public class ApiCallMaker {
             bw.close();
         }
 
-//        System.out.println(connection.getResponseCode());
+        System.out.println(connection.getResponseCode());
         BufferedReader br = new BufferedReader(new InputStreamReader(connection.getInputStream()));
         StringBuilder res = new StringBuilder();
         String line = null;

--- a/Test2/app/src/main/java/com/example/test2/FriendListPage.java
+++ b/Test2/app/src/main/java/com/example/test2/FriendListPage.java
@@ -97,6 +97,7 @@ public class FriendListPage extends AppCompatActivity {
 
             String friendEmails = "";
             String friendNames = "";
+            String friendList = "";
 
             try {
                 req.put("token", Utility.token);
@@ -111,9 +112,11 @@ public class FriendListPage extends AppCompatActivity {
                 res = apicall.callGet("http://10.0.2.2:8080/friends/getFriendList", headerMap, paramMap);
                 friendEmails = res.get("friendEmails").toString();
                 friendNames = res.get("friendNames").toString();
+                friendList = res.get("friendList").toString();
 
                 Log.w("friendEmails", friendEmails);
                 Log.w("friendNames", friendNames);
+                Log.w("friendList", friendList);
             }  catch (Exception e) {
                 e.printStackTrace();
             }

--- a/Test2/app/src/main/java/com/example/test2/FriendListPage.java
+++ b/Test2/app/src/main/java/com/example/test2/FriendListPage.java
@@ -95,7 +95,8 @@ public class FriendListPage extends AppCompatActivity {
             JSONObject res = new JSONObject();
             JSONObject req = new JSONObject();
 
-            String friendList = "";
+            String friendEmails = "";
+            String friendNames = "";
 
             try {
                 req.put("token", Utility.token);
@@ -108,14 +109,16 @@ public class FriendListPage extends AppCompatActivity {
 
             try {
                 res = apicall.callGet("http://10.0.2.2:8080/friends/getFriendList", headerMap, paramMap);
-                friendList = res.get("friendList").toString();
+                friendEmails = res.get("friendEmails").toString();
+                friendNames = res.get("friendNames").toString();
 
-                Log.w("friendList", friendList);
+                Log.w("friendEmails", friendEmails);
+                Log.w("friendNames", friendNames);
             }  catch (Exception e) {
                 e.printStackTrace();
             }
 
-            return friendList;
+            return friendEmails;
         }
 
 

--- a/backendserver/src/main/java/com/moneytransfer/backendserver/controllers/FriendContoller.java
+++ b/backendserver/src/main/java/com/moneytransfer/backendserver/controllers/FriendContoller.java
@@ -142,7 +142,7 @@ public class FriendContoller {
         List<String> friendNames = friendService.getFriendNames(requesterEmail);
         JSONObject res = makeStatusResponse(null, null);
         res.put("friendEmails", friendEmails);
-        res.put("friendNNames", friendNames);
+        res.put("friendNames", friendNames);
 
         return res.toString();
     }

--- a/backendserver/src/main/java/com/moneytransfer/backendserver/controllers/FriendContoller.java
+++ b/backendserver/src/main/java/com/moneytransfer/backendserver/controllers/FriendContoller.java
@@ -15,7 +15,9 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.UnsupportedEncodingException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Controller
 public class FriendContoller {
@@ -140,9 +142,13 @@ public class FriendContoller {
 
         List<String> friendEmails = friendService.getFriendEmails(requesterEmail);
         List<String> friendNames = friendService.getFriendNames(requesterEmail);
+
+        Map<String, String> friendList = friendService.getFriendList(requesterEmail);
+
         JSONObject res = makeStatusResponse(null, null);
         res.put("friendEmails", friendEmails);
         res.put("friendNames", friendNames);
+        res.put("friendList", friendList);
 
         return res.toString();
     }

--- a/backendserver/src/main/java/com/moneytransfer/backendserver/controllers/FriendContoller.java
+++ b/backendserver/src/main/java/com/moneytransfer/backendserver/controllers/FriendContoller.java
@@ -138,9 +138,11 @@ public class FriendContoller {
             return makeStatusResponse(e, null).toString();
         }
 
-        List<String> friendList = friendService.getFriendList(requesterEmail);
+        List<String> friendEmails = friendService.getFriendEmails(requesterEmail);
+        List<String> friendNames = friendService.getFriendNames(requesterEmail);
         JSONObject res = makeStatusResponse(null, null);
-        res.put("friendList", friendList);
+        res.put("friendEmails", friendEmails);
+        res.put("friendNNames", friendNames);
 
         return res.toString();
     }

--- a/backendserver/src/main/java/com/moneytransfer/backendserver/services/userService/FriendService.java
+++ b/backendserver/src/main/java/com/moneytransfer/backendserver/services/userService/FriendService.java
@@ -8,7 +8,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Service
 @Transactional(readOnly = true)
@@ -90,6 +92,20 @@ public class FriendService {
             fListName.add(fName);
         }
         return fListName;
+    }
+
+    public Map<String, String> getFriendList(String userEmail) {
+        Map<String, String> friendList = new HashMap<>();
+        List<Friend> fList = friendRepo.getUserFriends(userEmail);
+
+        for (Friend friend : fList) {
+            String fEmail = friend.getFriendAEmail().equals(userEmail)
+                    ? friend.getFriendBEmail() : friend.getFriendAEmail();
+            String fName = userRepo.findByUserEmail(fEmail).get().getName();
+
+            friendList.put(fEmail, fName);
+        }
+        return friendList;
     }
 
     public List<String> getRequest(String userEmail) {

--- a/backendserver/src/main/java/com/moneytransfer/backendserver/services/userService/FriendService.java
+++ b/backendserver/src/main/java/com/moneytransfer/backendserver/services/userService/FriendService.java
@@ -72,7 +72,7 @@ public class FriendService {
         return true;
     }
 
-    public List<String> getFriendList(String userEmail) {
+    public List<String> getFriendEmails(String userEmail) {
         List<Friend> fList = friendRepo.getUserFriends(userEmail);
         List<String> retList = new ArrayList<>();
         for (Friend friend : fList) {
@@ -80,6 +80,16 @@ public class FriendService {
                     ? friend.getFriendBEmail() : friend.getFriendAEmail());
         }
         return retList;
+    }
+
+    public List<String> getFriendNames(String userEmail) {
+        List<String> fListEmail = getFriendEmails(userEmail);
+        List<String> fListName = new ArrayList<>();
+        for (String fEmail : fListEmail) {
+            String fName = userRepo.findByUserEmail(fEmail).get().getName();
+            fListName.add(fName);
+        }
+        return fListName;
     }
 
     public List<String> getRequest(String userEmail) {


### PR DESCRIPTION
As requested by front-end team, lists of both friends' emails("friendEmails") and names("friendNames") can now be retrieved. 
That being said, the name of keys in res JSON object has been changed. I fixed the front-end part accordingly but I might've missed some parts, so please make sure to update to/use new key names. 

** UPDATE **
I just included all three lists in res for now: 
(1) list of names("friendNames")
(2) list of emails("friendEmails")
(3) map {email:name} ("friendList"). 
Let me know which one you will use, then I will delete the others.